### PR TITLE
upgrade actix-identity to fix random panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ dotenv = "0.15"
 
 actix-web = {version = "2.0", features = []}
 actix-rt = "1.0"
-actix-identity = "0.2"
+actix-identity = "0.2.1"
 futures = "0.3"
 
 diesel = { version = "1.4", features = ["postgres", "uuidv07", "chrono", "r2d2"] }


### PR DESCRIPTION
I was able to reproduce this issue pretty easily with bombardier of 10000 logins on ubuntu 18.04

https://github.com/actix/actix-web/issues/1263

upgrade has helped