### PR TITLE
Use shared pool across actix-web workers with app_data() approach

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod schema;
 mod user;
 
 use actix_identity::{CookieIdentityPolicy, IdentityService};
-use actix_web::{App, HttpServer};
+use actix_web::{App, HttpServer, web};
 
 #[actix_rt::main]
 async fn main() -> std::io::Result<()> {
@@ -29,10 +29,11 @@ async fn main() -> std::io::Result<()> {
     let secure_cookie = opt.secure_cookie;
     let auth_duration = chrono::Duration::hours(i64::from(opt.auth_duration_in_hour));
     let port = opt.port;
+    let pool = web::Data::new(database::pool::establish_connection(opt.clone()));
 
     let server = HttpServer::new(move || {
         App::new()
-            .data(database::pool::establish_connection(opt.clone()))
+            .app_data(pool.clone())
             .data(schema.clone())
             .data(opt.clone())
             .wrap(IdentityService::new(


### PR DESCRIPTION
When you run this boilerplate on Ryzen 3900 with 12 cores(24 threads) you will get the number of connection reached the limit error
The situation is that HttServer will start by default some predefined by the operating system

https://docs.rs/actix-web/2.0.0/actix_web/struct.HttpServer.html#method.workers

in my case, I've got 15
At the same time, the default pool size is 10

https://docs.rs/r2d2/0.8.8/r2d2/struct.Builder.html#method.max_size

So on my system, I needed 150 connections, but the default limit in docker-compose.yml is 100.
But based on
https://wiki.postgresql.org/wiki/Number_Of_Database_Connections

> A formula that has held up pretty well across a lot of benchmarks for years is that for optimal throughput the number of active connections should be somewhere near ((core_count * 2) + effective_spindle_count). Core count should not include HT threads, even if hyperthreading is enabled


so it just did not make sense to increase the number of connections and I did not want to manipulate the number of workers and max_size(). So I tried to use app_data() to pass pool as shared across workers and the number of connections defaulted to 10. I have also tested using bombardier with 10000 login requests and did not see any degradations of performance.

PS 
I have used
`select count(*) from pg_stat_activity;`
the command to get the number of active connections