### PR TITLE
Switch to graphql playground that has many features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "actix-identity"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix-service 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -441,7 +441,7 @@ dependencies = [
 name = "canduma"
 version = "0.2.0"
 dependencies = [
- "actix-identity 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-identity 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-rt 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2048,7 +2048,7 @@ dependencies = [
 "checksum actix-codec 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09e55f0a5c2ca15795035d90c46bd0e73a5123b72f68f12596d6ba5282051380"
 "checksum actix-connect 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2b61480a8d30c94d5c883d79ef026b02ad6809931b0a4bb703f9545cd8c986"
 "checksum actix-http 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c16664cc4fdea8030837ad5a845eb231fb93fc3c5c171edfefb52fad92ce9019"
-"checksum actix-identity 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aed3cac9bc27ad772311f0b4c727713842d776a60808c59f0e6fa1f917bef8f5"
+"checksum actix-identity 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a379b0639c293292d71defb8cc1f94c87b7705c904adf044338ad392df77c7a"
 "checksum actix-macros 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "21705adc76bbe4bc98434890e73a89cd00c6015e5704a60bb6eea6c3b72316b6"
 "checksum actix-router 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9d7a10ca4d94e8c8e7a87c5173aba1b97ba9a6563ca02b0e1cd23531093d3ec8"
 "checksum actix-rt 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6a0a55507046441a496b2f0d26a84a65e67c8cafffe279072412f624b5fb6d"

--- a/src/graphql/handler.rs
+++ b/src/graphql/handler.rs
@@ -4,7 +4,7 @@ use crate::graphql::model::{Context, Schema};
 use crate::jwt::model::DecodedToken;
 use crate::user::model::LoggedUser;
 use actix_web::{error, web, Error, HttpResponse};
-use juniper::http::graphiql::graphiql_source;
+use juniper::http::playground::playground_source;
 use juniper::http::GraphQLRequest;
 use std::sync::Arc;
 
@@ -29,8 +29,8 @@ pub(super) async fn graphql(
         .body(json))
 }
 
-pub(super) fn graphiql(opt: web::Data<Opt>) -> HttpResponse {
-    let html = graphiql_source(&format!("http://127.0.0.1:{}/graphql", opt.port));
+pub(super) fn playground(opt: web::Data<Opt>) -> HttpResponse {
+    let html = playground_source(&format!("http://{}:{}/graphql", opt.domain, opt.port));
     HttpResponse::Ok()
         .content_type("text/html; charset=utf-8")
         .body(html)

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -5,5 +5,5 @@ pub mod model;
 
 pub(super) fn route(cfg: &mut web::ServiceConfig) {
     cfg.service(web::resource("/graphql").route(web::post().to(handler::graphql)))
-        .service(web::resource("/graphiql").route(web::get().to(handler::graphiql)));
+        .service(web::resource("/").route(web::get().to(handler::playground)));
 }


### PR DESCRIPTION
* Switch to graphql playground that has many features 
see https://github.com/prisma-labs/graphql-playground
* Fixed "No schema found issue", playground (and graphiql) should be home page to work correctly.
* Properly use opt.domain parameter to avoid CORS issues
* Fixed Cargo.lock file as I have missed committing for #23 